### PR TITLE
Publish to gh-pages

### DIFF
--- a/.config/rm_old_folders.py
+++ b/.config/rm_old_folders.py
@@ -1,0 +1,63 @@
+import argparse
+import os
+import re
+from datetime import datetime, timedelta
+import shutil
+
+def find_old_folders(retention_days, directory):
+    """
+    Find folders in the specified directory that are older than retention_days.
+    
+    Args:
+        directory (str): The directory to search for folders.
+        retentioretention_days (int): The number of days to determine which folders to delete.
+
+    Returns:
+        list: List of folder names older than retention_days.
+    """
+    current_time = datetime.utcnow()
+    folder_name_regex = re.compile(r'^\d{8}_\d{6}Z$')
+
+    old_folders = []
+    for entry in os.scandir(directory):
+        if entry.is_dir() and re.match(folder_name_regex, entry.name):
+            try:
+                folder_date = datetime.strptime(entry.name, "%Y%m%d_%H%M%SZ")
+                time_difference = current_time - folder_date
+                if time_difference > timedelta(days=retention_days):
+                    old_folders.append(entry.name)
+                else:
+                    print(f"SKIPPED --- Folder '{entry.name}' is not older than {retention_days}. It will not be deleted")
+            except ValueError:
+                print(f"SKIPPED --- Error parsing timestamp for folder '{entry.name}'. It will not be deleted.")
+        else:
+            print(f"SKIPPED --- Found folder/file with name '{entry.name}' that does not match the expected timestamp format. It will not be deleted.")
+
+    return old_folders
+
+def delete_folders(directory, folder_names):
+    """
+    Delete specified folders and their contents in the given directory.
+    
+    Args:
+        directory (str): The directory containing the folders to delete.
+        folder_names (list): List of folder names to delete.
+    """
+    for folder_name in folder_names:
+        folder_path = os.path.join(directory, folder_name)
+        try:
+            shutil.rmtree(folder_path)
+            print(f"DELETED --- Folder '{folder_name}' and its contents have been deleted.")
+        except FileNotFoundError:
+            print(f"Folder '{folder_name}' not found.")
+        except Exception as e:
+            print(f"Error deleting folder '{folder_name}': {e}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Delete old folders in a specified directory.")
+    parser.add_argument("--retention-days", type=int, required=True, help="Number of days (days older than current date) to determine which folders to delete.")
+    parser.add_argument("--folder-name", type=str, required=True, help="Full path to the directory where reports are located.")
+    args = parser.parse_args()
+
+    old_folders = find_old_folders(args.retention_days, args.folder_name)
+    delete_folders(args.folder_name, old_folders)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
     - cron: '12 13 * * *' #once a day at 11 UTC
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -200,19 +200,33 @@ jobs:
           path: grafana-server.log
           retention-days: 5
 
-      - name: Publish report to GCS
-        if: ${{ github.repository_owner == 'grafana' && (failure() && steps.run-tests.outcome == 'failure') }}
-        uses: grafana/plugin-actions/publish-report@main
-        with:
-          grafana-version: ${{ matrix.GRAFANA_IMAGE.VERSION }}
-          path: playwright-report
+      - name: Set a timestamp
+        id: timestampid
+        run: echo "timestamp=$(date --utc +%Y%m%d_%H%M%SZ)" >> "$GITHUB_OUTPUT"
 
-      # Uncomment this step to upload the Playwright report to Github artifacts.
-      # If your repository is public, the report will be public on the Internet so beware not to expose sensitive information.
-      # - name: Upload artifacts
-      #   uses: actions/upload-artifact@v4
-      #   if: ${{ always() && steps.run-tests.outcome == 'failure' }}
-      #   with:
-      #     name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
-      #     path: playwright-report/
-      #     retention-days: 5
+      - name: Push the new files to github pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: playwright-report
+          destination_dir: ${{ steps.timestampid.outputs.timestamp }}/${{ github.event.number }}/${{ matrix.GRAFANA_IMAGE.VERSION }}
+
+      - name: Write URL in summary
+        run: echo "### Browse the Playwright report for Grafana-v${{ matrix.GRAFANA_IMAGE.VERSION }} - https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ steps.timestampid.outputs.timestamp }}/${{ github.event.number }}/${{ matrix.GRAFANA_IMAGE.VERSION }}/" >> $GITHUB_STEP_SUMMARY
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+
+      - name: Delete old reports
+        run: python .config/rm_old_folders.py --retention-days 30 --folder-name .
+
+      - name: Commit all changed files back to the repository
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: gh-pages
+          commit_message: Delete folders older than n days


### PR DESCRIPTION
This PR extends the CI workflow so that the Playwright reports are published to GH pages. Implementation is inspired by [this](https://blog.martioli.com/publish-your-playwright-reports-to-github-pages/) blog post. 

Each published report will be stored in the gh-pages branch using the following pattern: `<timestamp>/<pr-number>/<grafana-version>`. e.g `20250101_083234Z/8/8.5.27`. GH pages can only store 1GB of data, so at the end of the workflow there's a cleanup step that removes the old reports. 