### PR TITLE
test: use nightly image branch for e2e-version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@main
+        uses: grafana/plugin-actions/e2e-version@feat/e2e-version-switch-to-nightly
         with:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
         with:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'
+          skip-grafana-dev-image: false
 
   playwright-tests:
     needs: [resolve-versions, build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
           DEVELOPMENT=false GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
 
       - name: Wait for grafana server
-        uses: grafana/plugin-actions/wait-for-grafana@main
+        uses: grafana/plugin-actions/wait-for-grafana@fix/wait-for-grafana-smarter-timeout
 
       - name: Install Playwright Browsers
         run: npm exec playwright install chromium --with-deps


### PR DESCRIPTION
Points the e2e-version action to grafana/plugin-actions#216 to test the switch from grafana-dev to grafana-enterprise:nightly in the E2E matrix.