### PR TITLE
chore(renovate): group non-major dev dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,13 @@
     "github>grafana/grafana-renovate-config//presets/helm",
     "github>grafana/grafana-renovate-config//presets/shared-workflows",
     "github>grafana/grafana-renovate-config//presets/rate-limits"
+  ],
+  "packageRules": [
+    {
+      "description": "group all non-major dev dependency updates into a single PR to reduce noise",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "devDependencies (non-major)"
+    }
   ]
 }


### PR DESCRIPTION
Groups all non-major `devDependencies` updates into a single Renovate PR instead of one PR per package, to cut the volume of open dependency PRs.
